### PR TITLE
remove `$` from environment value name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ to follow XDG conventions and read a `~/.config/app-name.edn` file.
 
 This will check, in order, until it's found a value:
 
-- The `$APP_NAME__HTTP__PORT` environment variable
+- The `APP_NAME__HTTP__PORT` environment variable
 - The `app-name.http.port` Java system property (`System/getProperty`)
 - `config.local.edn` in the JVM's CWD
 - `$XDG_CONFIG_HOME/app-name.edn`


### PR DESCRIPTION
remove `$` from environment value name.

The `$APP_NAME__HTTP__PORT` environment variable might be misinterpreted as referring to the `$APP_NAME__HTTP__PORT` environment variable.
Writing it as "the `APP_NAME__HTTP__PORT` environment variable" would avoid any potential misunderstandings and clearly convey the information.
